### PR TITLE
Feature/auto vivification

### DIFF
--- a/qbt-manifest
+++ b/qbt-manifest
@@ -529,10 +529,11 @@ misc1,HEAD:f56fe72c4f9651641088091c843515dbbd23bbce
         Strong:misc1.third_party_tools.main,HEAD
         Weak:3p.gradle,HEAD
         Weak:qbt_fringe.linter.release,HEAD
-qbt,HEAD:ca81686ae8114cdff870f31f4081a4bf3ac12078
+qbt,HEAD:d0d0136669f4771ccb0b7b5a8d4902b8aec7ac86
     qbt.app.main
         Metadata:archIndependent=true
         Metadata:prefix=app/main
+        Strong:mc.com.google.code.gson.gson,HEAD
         Strong:mc.org.apache.httpcomponents.httpclient,HEAD
         Strong:mc.org.codehaus.groovy.groovy.all,HEAD
         Strong:misc1.commons.concurrent.main,HEAD

--- a/qbt-manifest
+++ b/qbt-manifest
@@ -529,7 +529,7 @@ misc1,HEAD:f56fe72c4f9651641088091c843515dbbd23bbce
         Strong:misc1.third_party_tools.main,HEAD
         Weak:3p.gradle,HEAD
         Weak:qbt_fringe.linter.release,HEAD
-qbt,HEAD:0cb7f3469aee6556617b3f9cba4bb11f4f07db9d
+qbt,HEAD:ca81686ae8114cdff870f31f4081a4bf3ac12078
     qbt.app.main
         Metadata:archIndependent=true
         Metadata:prefix=app/main


### PR DESCRIPTION
Using github remotes, repositories are now auto-vivified.

To use, add the following to your config file:
    import qbt.remote.GithubQbtRemote;
    // ...snip
    cmyers: new GithubQbtRemote(
                gitRemoteVcs,
                token,
                "TerabyteQbt",
    // optional 5th argument is format string, defaults to "%r"
            ),

In order to create repositories, you need to generate a github API token.  To do this, go to https://github.com/settings/tokens and generate a token with public_repo permission.

Finally, before the lines above, add:

```
def token = "TOKEN_HERE";
```

or something like:

```
def token = new File('/home/cmyers/.github-api-token').text.trim();
```

if you prefer to store the token in a file.

An old config file is 100% compatible with this change, nothing should break.
