### PR TITLE
Transforming LocalRepoFinder and QbtRemote classes.

### DIFF
--- a/qbt-manifest
+++ b/qbt-manifest
@@ -2206,7 +2206,7 @@
                 }
             }
         },
-        "version": "6b09307ffd7af1eb7810d595108de34e502e512c"
+        "version": "3be9efbdbdbc4d851cbf05e7b92f1295cdf08952"
     },
     "wrapper_generator": {
         "packages": {


### PR DESCRIPTION
These classes allow the user to map a repo to a different name locally on disk
and on the server, allowing those places to use names which contain otherwise
invalid characters for repo names.

Resolves TerabyteQbt/meta#5 and mitigates TerabyteQbt/meta#4.

See commit message for example QbtConfig