### PR TITLE
qbt version command

### DIFF
--- a/qbt-manifest
+++ b/qbt-manifest
@@ -2123,7 +2123,7 @@
                 }
             }
         },
-        "version": "7de4b3647d742fc3834a0035f3e63c224d22813a"
+        "version": "4e257aab80a080cde447d5c5958b74a881a9b8a0"
     },
     "wrapper_generator": {
         "packages": {


### PR DESCRIPTION
One can now print the CV of meta_tools and qbt.app.main by invoking 'qbt
version'.  There is also infrastructure to easily add version information for
other applications based upon qbt.bin.

Resolves TerabyteQbt/meta#6

Here is what the output looks like with and without a "release string":
```
$ qbt runArtifact --package meta_tools.release bin/qbt version
meta_tools.release (cv 686956c8413849de347f92bbb3cf882ca8a7e934)
qbt.app.main (cv 8c19167bbc3dae14f7c8eea5a70f3a011af49088)
$ qbt runArtifact --package meta_tools.release --qbtEnv RELEASE_STRING="1.0 (built on $(date))" bin/qbt version
meta_tools.release (cv 0cf0488c5ecab72ab73e83097bbe19572101f316) release 1.0 (built on Sat Mar  3 01:50:12 PST 2018)
qbt.app.main (cv 6af541053ccecb8d774dafffd479fcb9afbf733a) release 1.0 (built on Sat Mar  3 01:50:12 PST 2018)
```